### PR TITLE
Fix python3 bytes and str compatibility

### DIFF
--- a/cpioarchive.py
+++ b/cpioarchive.py
@@ -26,7 +26,7 @@ interface for interacting with the entry."""
     """Create a new CpioEntry instance. Internal use only."""
     if len(hdr)<110:
       raise CpioError('cpio header too short')
-    if not hdr.startswith('070701'):
+    if not hdr.startswith(b'070701'):
       raise CpioError('cpio header invalid')
     self.inode=int(hdr[6:14], 16)
     self.mode=int(hdr[14:22], 16)
@@ -44,7 +44,7 @@ interface for interacting with the entry."""
     self.checksum=int(hdr[102:110], 16)
     if len(hdr)<110+namesize:
       raise CpioError('cpio header too short')
-    self.name=hdr[110:110+namesize-1]
+    self.name=hdr[110:110+namesize-1].decode("utf-8")
     """Name of the file stored in the entry."""
     self.datastart=offset+110+namesize
     self.datastart+=(4-(self.datastart%4))%4
@@ -156,7 +156,7 @@ fileobj -- File object to use (default: open by filename instead)
     return iter(self._infos)
 
   def _readfile(self, name):
-    self._readobj(file(name, 'rb'))
+    self._readobj(open(name, 'rb'))
     
   def _readobj(self, fileobj):
     self.file=fileobj


### PR DESCRIPTION
Compare the header to a bytes object and store entry name as a string.

Below is output of simple testing:
```
python -c 'import cpioarchive; archive = cpioarchive.CpioArchive("/tmp/scap_cpio"); print([entry.name for entry in archive])'
07070100000001000081a40000000000000000000000015bb1e075000013d8000000000000000000000000000000000000003400000000
[u'./usr/share/doc/scap-security-guide/Contributors.md', u'./usr/share/doc/scap-security-guide/LICENSE', u'./usr/share/doc/scap-security-guide/README.md', u'./usr/share/man/man8/scap-security-guide.8.gz', u'./usr/share/scap-security-guide/ansible', u'./usr/share/scap-security-guide/ansible/ssg-fedora-role-default.yml', u'./usr/share/scap-security-guide/ansible/ssg-fedora-role-ospp.yml', u'./usr/share/scap-security-guide/ansible/ssg-fedora-role-pci-dss.yml', u'./usr/share/scap-security-guide/ansible/ssg-fedora-role-standard.yml', u'./usr/share/scap-security-guide/bash', u'./usr/share/scap-security-guide/bash/ssg-fedora-role-default.sh', u'./usr/share/scap-security-guide/bash/ssg-fedora-role-ospp.sh', u'./usr/share/scap-security-guide/bash/ssg-fedora-role-pci-dss.sh', u'./usr/share/scap-security-guide/bash/ssg-fedora-role-standard.sh', u'./usr/share/xml/scap/ssg/content', u'./usr/share/xml/scap/ssg/content/ssg-fedora-cpe-dictionary.xml', u'./usr/share/xml/scap/ssg/content/ssg-fedora-cpe-oval.xml', u'./usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml', u'./usr/share/xml/scap/ssg/content/ssg-fedora-ocil.xml', u'./usr/share/xml/scap/ssg/content/ssg-fedora-oval.xml', u'./usr/share/xml/scap/ssg/content/ssg-fedora-xccdf.xml']
```
```
$ python3 -c 'import cpioarchive; archive = cpioarchive.CpioArchive("/tmp/scap_cpio"); print([entry.name for entry in archive])'
b'07070100000001000081a40000000000000000000000015bb1e075000013d8000000000000000000000000000000000000003400000000'
['./usr/share/doc/scap-security-guide/Contributors.md', './usr/share/doc/scap-security-guide/LICENSE', './usr/share/doc/scap-security-guide/README.md', './usr/share/man/man8/scap-security-guide.8.gz', './usr/share/scap-security-guide/ansible', './usr/share/scap-security-guide/ansible/ssg-fedora-role-default.yml', './usr/share/scap-security-guide/ansible/ssg-fedora-role-ospp.yml', './usr/share/scap-security-guide/ansible/ssg-fedora-role-pci-dss.yml', './usr/share/scap-security-guide/ansible/ssg-fedora-role-standard.yml', './usr/share/scap-security-guide/bash', './usr/share/scap-security-guide/bash/ssg-fedora-role-default.sh', './usr/share/scap-security-guide/bash/ssg-fedora-role-ospp.sh', './usr/share/scap-security-guide/bash/ssg-fedora-role-pci-dss.sh', './usr/share/scap-security-guide/bash/ssg-fedora-role-standard.sh', './usr/share/xml/scap/ssg/content', './usr/share/xml/scap/ssg/content/ssg-fedora-cpe-dictionary.xml', './usr/share/xml/scap/ssg/content/ssg-fedora-cpe-oval.xml', './usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml', './usr/share/xml/scap/ssg/content/ssg-fedora-ocil.xml', './usr/share/xml/scap/ssg/content/ssg-fedora-oval.xml', './usr/share/xml/scap/ssg/content/ssg-fedora-xccdf.xml']
```

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1240325